### PR TITLE
Fix submodule update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ vol-test supports testing against remote environments. Remote Docker hosts shoul
     ```
     git clone https://github.com/khudgins/vol-test
     cd vol-tests
+    git submodule init
     git submodule update --recursive --remote
     ```
 


### PR DESCRIPTION
On the first install we need to do a
"submodule init" before the update.